### PR TITLE
Travis: configure JRUBY_OPTS to enable the ObjectSpace features

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,14 +6,17 @@ addons:
   apt:
     packages:
     - bind9
-rvm:
-  - 2.1
-  - 2.2
-  - 2.3
-  - 2.4
-  - ruby-head
-  - jruby-head
+
 matrix:
+  include:
+    - rvm: 2.1
+    - rvm: 2.2
+    - rvm: 2.3
+    - rvm: 2.4
+    - rvm: ruby-head
+    - rvm: jruby-head
+      env:
+        - JRUBY_OPTS="--debug -X+O"
   allow_failures:
     - rvm: ruby-head
     - rvm: jruby-head


### PR DESCRIPTION
This PR adds a necessary JRuby configuration option to the CI matrix: the option to enable the ObjectSpace features of Ruby.

To make that change easy, this PR simplifies the Travis configuration's `matrix` section to hold all the build information.

---

This change is only a small part of making JRuby run the test suite, but it is a start which can be done in this repository.

Fixes #2 