### PR TITLE
Avoid Ruby warnings

### DIFF
--- a/lib/async/dns/replace.rb
+++ b/lib/async/dns/replace.rb
@@ -24,7 +24,7 @@ require 'resolv-replace'
 module Async::DNS
 	module Replace
 		class << self
-			attr :resolver, true
+			attr_accessor :resolver
 			
 			def resolver?
 				resolver != nil

--- a/lib/async/dns/resolver.rb
+++ b/lib/async/dns/resolver.rb
@@ -97,14 +97,14 @@ module Async::DNS
 			retries = options.fetch(:retries, DEFAULT_RETRIES)
 			delay = options.fetch(:delay, DEFAULT_DELAY)
 			
-			records = lookup(name, resource_class, cache) do |name, resource_class|
+			records = lookup(name, resource_class, cache) do |lookup_name, lookup_resource_class|
 				response = nil
 				
 				retries.times do |i|
 					# Wait 10ms before trying again:
 					sleep delay if delay and i > 0
 					
-					response = query(name, resource_class)
+					response = query(lookup_name, lookup_resource_class)
 					
 					break if response
 				end
@@ -175,8 +175,8 @@ module Async::DNS
 				response = yield(name, resource_class)
 				
 				if response
-					response.answer.each do |name, ttl, record|
-						(records[name] ||= []) << record
+					response.answer.each do |name_in_answer, ttl, record|
+						(records[name_in_answer] ||= []) << record
 					end
 				end
 				


### PR DESCRIPTION
This PR tries to remedy the warnings in this gem that are output in CI test runs:

```
/home/travis/build/socketry/async-dns/lib/async/dns/resolver.rb:100:
  warning: shadowing outer local variable - name
/home/travis/build/socketry/async-dns/lib/async/dns/resolver.rb:100:
  warning: shadowing outer local variable - resource_class
/home/travis/build/socketry/async-dns/lib/async/dns/resolver.rb:178:
  warning: shadowing outer local variable - name
/home/travis/build/socketry/async-dns/lib/async/dns/replace.rb:27:
  warning: optional boolean argument is obsoleted
```