### PR TITLE
Doc fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Async::Reactor.run do
 
 	puts addresses.inspect
 end
-=> [#<Resolv::IPv4 202.124.127.240>, #<Resolv::IPv4 202.124.127.216>, #<Resolv::IPv4 202.124.127.223>, #<Resolv::IPv4 202.124.127.227>, #<Resolv::IPv4 202.124.127.234>, #<Resolv::IPv4 202.124.127.230>, #<Resolv::IPv4 202.124.127.208>, #<Resolv::IPv4 202.124.127.249>, #<Resolv::IPv4 202.124.127.219>, #<Resolv::IPv4 202.124.127.218>, #<Resolv::IPv4 202.124.127.212>, #<Resolv::IPv4 202.124.127.241>, #<Resolv::IPv4 202.124.127.238>, #<Resolv::IPv4 202.124.127.245>, #<Resolv::IPv4 202.124.127.251>, #<Resolv::IPv4 202.124.127.229>]
+# [#<Resolv::IPv4 202.124.127.240>, #<Resolv::IPv4 202.124.127.216>, #<Resolv::IPv4 202.124.127.223>, #<Resolv::IPv4 202.124.127.227>, #<Resolv::IPv4 202.124.127.234>, #<Resolv::IPv4 202.124.127.230>, #<Resolv::IPv4 202.124.127.208>, #<Resolv::IPv4 202.124.127.249>, #<Resolv::IPv4 202.124.127.219>, #<Resolv::IPv4 202.124.127.218>, #<Resolv::IPv4 202.124.127.212>, #<Resolv::IPv4 202.124.127.241>, #<Resolv::IPv4 202.124.127.238>, #<Resolv::IPv4 202.124.127.245>, #<Resolv::IPv4 202.124.127.251>, #<Resolv::IPv4 202.124.127.229>]
 ```
 
 ### Server

--- a/README.md
+++ b/README.md
@@ -51,7 +51,6 @@ class TestServer < Async::DNS::Server
 end
 
 server = TestServer.new([[:udp, '127.0.0.1', 2346]])
-
 server.run
 ```
 

--- a/README.md
+++ b/README.md
@@ -25,14 +25,14 @@ Or install it yourself as:
 Here is a simple example showing how to use the resolver:
 
 ``` ruby
-	Async::Reactor.run do
-		resolver = Async::DNS::Resolver.new([[:udp, "8.8.8.8", 53], [:tcp, "8.8.8.8", 53]])
+Async::Reactor.run do
+	resolver = Async::DNS::Resolver.new([[:udp, "8.8.8.8", 53], [:tcp, "8.8.8.8", 53]])
 
-		addresses = resolver.addresses_for("www.google.com.")
+	addresses = resolver.addresses_for("www.google.com.")
 
-		puts addresses.inspect
-	end
-	=> [#<Resolv::IPv4 202.124.127.240>, #<Resolv::IPv4 202.124.127.216>, #<Resolv::IPv4 202.124.127.223>, #<Resolv::IPv4 202.124.127.227>, #<Resolv::IPv4 202.124.127.234>, #<Resolv::IPv4 202.124.127.230>, #<Resolv::IPv4 202.124.127.208>, #<Resolv::IPv4 202.124.127.249>, #<Resolv::IPv4 202.124.127.219>, #<Resolv::IPv4 202.124.127.218>, #<Resolv::IPv4 202.124.127.212>, #<Resolv::IPv4 202.124.127.241>, #<Resolv::IPv4 202.124.127.238>, #<Resolv::IPv4 202.124.127.245>, #<Resolv::IPv4 202.124.127.251>, #<Resolv::IPv4 202.124.127.229>]
+	puts addresses.inspect
+end
+=> [#<Resolv::IPv4 202.124.127.240>, #<Resolv::IPv4 202.124.127.216>, #<Resolv::IPv4 202.124.127.223>, #<Resolv::IPv4 202.124.127.227>, #<Resolv::IPv4 202.124.127.234>, #<Resolv::IPv4 202.124.127.230>, #<Resolv::IPv4 202.124.127.208>, #<Resolv::IPv4 202.124.127.249>, #<Resolv::IPv4 202.124.127.219>, #<Resolv::IPv4 202.124.127.218>, #<Resolv::IPv4 202.124.127.212>, #<Resolv::IPv4 202.124.127.241>, #<Resolv::IPv4 202.124.127.238>, #<Resolv::IPv4 202.124.127.245>, #<Resolv::IPv4 202.124.127.251>, #<Resolv::IPv4 202.124.127.229>]
 ```
 
 ### Server
@@ -40,19 +40,19 @@ Here is a simple example showing how to use the resolver:
 Here is a simple example showing how to use the server:
 
 ``` ruby
-	require 'async/dns'
-	
-	class TestServer < Async::DNS::Server
-		def process(name, resource_class, transaction)
-			@resolver ||= Async::DNS::Resolver.new([[:udp, '8.8.8.8', 53], [:tcp, '8.8.8.8', 53]])
-			
-			transaction.passthrough!(@resolver)
-		end
+require 'async/dns'
+
+class TestServer < Async::DNS::Server
+	def process(name, resource_class, transaction)
+		@resolver ||= Async::DNS::Resolver.new([[:udp, '8.8.8.8', 53], [:tcp, '8.8.8.8', 53]])
+		
+		transaction.passthrough!(@resolver)
 	end
-	
-	server = TestServer.new([[:udp, '127.0.0.1', 2346]])
-	
-	server.run
+end
+
+server = TestServer.new([[:udp, '127.0.0.1', 2346]])
+
+server.run
 ```
 
 Then to test you could use `dig` like so:

--- a/lib/async/dns/server.rb
+++ b/lib/async/dns/server.rb
@@ -59,6 +59,8 @@ module Async::DNS
 		attr_accessor :logger
 		
 		# Give a name and a record type, try to match a rule and use it for processing the given arguments.
+		#
+		# @abstract
 		def process(name, resource_class, transaction)
 			raise NotImplementedError.new
 		end

--- a/lib/async/dns/server.rb
+++ b/lib/async/dns/server.rb
@@ -25,6 +25,8 @@ require_relative 'transaction'
 
 module Async::DNS
 	#
+	# Base class for defining asynchronous DNS servers.
+	#
 	# ## Example
 	#
 	#     require 'async/dns'

--- a/lib/async/dns/server.rb
+++ b/lib/async/dns/server.rb
@@ -24,18 +24,27 @@ require 'async/io'
 require_relative 'transaction'
 
 module Async::DNS
+	#
+	# ## Example
+	#
+	#     require 'async/dns'
+	#     
+	#     class TestServer < Async::DNS::Server
+	#       def process(name, resource_class, transaction)
+	#         @resolver ||= Async::DNS::Resolver.new([[:udp, '8.8.8.8', 53], [:tcp, '8.8.8.8', 53]])
+	#     
+	#         transaction.passthrough!(@resolver)
+	#       end
+	#     end
+	#     
+	#     server = TestServer.new([[:udp, '127.0.0.1', 2346]])
+	#     server.run
+	#
 	class Server
 		# The default server interfaces
 		DEFAULT_ENDPOINTS = [[:udp, "0.0.0.0", 53], [:tcp, "0.0.0.0", 53]]
 		
 		# Instantiate a server with a block
-		#
-		#	server = Server.new do
-		#		match(/server.mydomain.com/, IN::A) do |transaction|
-		#			transaction.respond!("1.2.3.4")
-		#		end
-		#	end
-		#
 		def initialize(endpoints = DEFAULT_ENDPOINTS, origin: '.', logger: Console.logger)
 			@endpoints = endpoints
 			@origin = origin

--- a/lib/async/dns/server.rb
+++ b/lib/async/dns/server.rb
@@ -43,10 +43,10 @@ module Async::DNS
 	#     server.run
 	#
 	class Server
-		# The default server interfaces
+		# The default server interfaces.
 		DEFAULT_ENDPOINTS = [[:udp, "0.0.0.0", 53], [:tcp, "0.0.0.0", 53]]
 		
-		# Instantiate a server with a block
+		# Instantiate a server with a block.
 		#
 		# @param endpoints [Array<(Symbol, String, Integer)>]  The endpoints to listen on.
 		# @param origin [String] The default origin to resolve domains within.
@@ -57,7 +57,7 @@ module Async::DNS
 			@logger = logger
 		end
 		
-		# Records are relative to this origin:
+		# Records are relative to this origin.
 		#
 		# @return [String]
 		attr_accessor :origin

--- a/lib/async/dns/server.rb
+++ b/lib/async/dns/server.rb
@@ -47,6 +47,10 @@ module Async::DNS
 		DEFAULT_ENDPOINTS = [[:udp, "0.0.0.0", 53], [:tcp, "0.0.0.0", 53]]
 		
 		# Instantiate a server with a block
+		#
+		# @param endpoints [Array<(Symbol, String, Integer)>]  The endpoints to listen on.
+		# @param origin [String] The default origin to resolve domains within.
+		# @param logger [Console::Logger] The logger to use.
 		def initialize(endpoints = DEFAULT_ENDPOINTS, origin: '.', logger: Console.logger)
 			@endpoints = endpoints
 			@origin = origin
@@ -54,12 +58,20 @@ module Async::DNS
 		end
 		
 		# Records are relative to this origin:
+		#
+		# @return [String]
 		attr_accessor :origin
 		
+		# The logger to use.
+		#
+		# @return [Console::Logger]
 		attr_accessor :logger
 		
 		# Give a name and a record type, try to match a rule and use it for processing the given arguments.
 		#
+		# @param name [String] The resource name.
+		# @param resource_class [Class<Resolv::DNS::Resource>] The requested resource class.
+		# @param transaction [Transaction] The transaction object.
 		# @abstract
 		def process(name, resource_class, transaction)
 			raise NotImplementedError.new

--- a/lib/async/dns/transaction.rb
+++ b/lib/async/dns/transaction.rb
@@ -153,7 +153,7 @@ module Async::DNS
 			end
 		end
 		
-		# This function indicates that there was a failure to resolve the given question. The single argument must be an integer error code, typically given by the constants in {Resolv::DNS::RCode}.
+		# This function indicates that there was a failure to resolve the given question. The single argument must be an integer error code, typically given by the constants in `Resolv::DNS::RCode`.
 		#
 		# The easiest way to use this function it to simply supply a symbol. Here is a list of the most commonly used ones:
 		#


### PR DESCRIPTION
Improve documentation of `Async::DNS::Server`.

* Removed old example for `Server#initialize` which referenced some kind of `match` method.
* Added a top-level example copied from the README.
* Added missing YARD tags.
* Fixed a YARD warning in `lib/async/dns/transaction.rb`.
* Tried my best to conform to your style (tab indentation, one-line `@param` tags, etc).

## Types of Changes

- Documentation.

## Contribution

<!-- Delete any which don't apply (you don't need to check all of them initially): -->

- [x] I tested my changes locally.
- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
