### PR TITLE
Default to system nameservers if a Resolver is initialized without any.

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,13 +26,23 @@ Here is a simple example showing how to use the resolver:
 
 ``` ruby
 Async::Reactor.run do
-	resolver = Async::DNS::Resolver.new([[:udp, "8.8.8.8", 53], [:tcp, "8.8.8.8", 53]])
+	resolver = Async::DNS::Resolver.new()
 
 	addresses = resolver.addresses_for("www.google.com.")
 
 	puts addresses.inspect
 end
 # [#<Resolv::IPv4 202.124.127.240>, #<Resolv::IPv4 202.124.127.216>, #<Resolv::IPv4 202.124.127.223>, #<Resolv::IPv4 202.124.127.227>, #<Resolv::IPv4 202.124.127.234>, #<Resolv::IPv4 202.124.127.230>, #<Resolv::IPv4 202.124.127.208>, #<Resolv::IPv4 202.124.127.249>, #<Resolv::IPv4 202.124.127.219>, #<Resolv::IPv4 202.124.127.218>, #<Resolv::IPv4 202.124.127.212>, #<Resolv::IPv4 202.124.127.241>, #<Resolv::IPv4 202.124.127.238>, #<Resolv::IPv4 202.124.127.245>, #<Resolv::IPv4 202.124.127.251>, #<Resolv::IPv4 202.124.127.229>]
+```
+
+You can also specify custom DNS servers:
+
+``` ruby
+resolver = Async::DNS::Resolver.new(Async::DNS::System.standard_connections(['8.8.8.8']))
+
+# or
+
+resolver = Async::DNS::Resolver.new([[:udp, "8.8.8.8", 53], [:tcp, "8.8.8.8", 53]])
 ```
 
 ### Server

--- a/lib/async/dns/resolver.rb
+++ b/lib/async/dns/resolver.rb
@@ -19,6 +19,7 @@
 # THE SOFTWARE.
 
 require_relative 'handler'
+require_relative 'system'
 
 require 'securerandom'
 require 'async'
@@ -46,8 +47,8 @@ module Async::DNS
 		# Servers are specified in the same manor as options[:listen], e.g.
 		#   [:tcp/:udp, address, port]
 		# In the case of multiple servers, they will be checked in sequence.
-		def initialize(endpoints, origin: nil, logger: Console.logger, timeout: DEFAULT_TIMEOUT)
-			@endpoints = endpoints
+		def initialize(endpoints = nil, origin: nil, logger: Console.logger, timeout: DEFAULT_TIMEOUT)
+			@endpoints = endpoints || System.nameservers
 			
 			@origin = origin
 			@logger = logger

--- a/spec/async/dns/resolver_spec.rb
+++ b/spec/async/dns/resolver_spec.rb
@@ -101,4 +101,13 @@ RSpec.describe Async::DNS::Resolver do
 		
 		expect(addresses.size).to be > 0
 	end
+
+	it "should default to system resolvers" do
+		resolver = Async::DNS::Resolver.new()
+
+		response = resolver.query('google.com')
+
+		expect(response.class).to be == Async::DNS::Message
+		expect(response.answer.size).to be > 0
+	end
 end


### PR DESCRIPTION
This change allows Resolver to be created without specifying nameservers.  When no nameservers are specified, the system resolver config is used.

## Types of Changes

- Quality of Life Improvement

## Contribution

- [x] I added tests for my changes.
- [x] I tested my changes locally.
- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
