### PR TITLE
Add `base64` as a dependency for Bundler (closes #35)

### DIFF
--- a/async-dns.gemspec
+++ b/async-dns.gemspec
@@ -24,6 +24,7 @@ Gem::Specification.new do |spec|
 	spec.files = Dir.glob(['{lib}/**/*', '*.md'], File::FNM_DOTMATCH, base: __dir__)
 	
 	spec.required_ruby_version = ">= 3.1"
-	
+
+  spec.add_dependency "base64"
 	spec.add_dependency "io-endpoint"
 end


### PR DESCRIPTION
## Types of Changes

Recently `base64` was changed from being a default gem to being a bundled gem. Bundler is now excluding base64 unless it is explicitly listed as a gem dependency, which prevents any project using `async-dns` from running their specs. This PR adds `base64` as a gem dependency to satisfy Bundler.

- Maintenance.

## Contribution

- [ ] I added tests for my changes.
- [x] I tested my changes locally.
- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).