### PR TITLE
Add missing `async` gem dependency

### DIFF
--- a/async-dns.gemspec
+++ b/async-dns.gemspec
@@ -25,6 +25,6 @@ Gem::Specification.new do |spec|
 	
 	spec.required_ruby_version = ">= 3.1"
 	
-  spec.add_dependency "async"	
+	spec.add_dependency "async"	
 	spec.add_dependency "io-endpoint"
 end

--- a/async-dns.gemspec
+++ b/async-dns.gemspec
@@ -25,5 +25,6 @@ Gem::Specification.new do |spec|
 	
 	spec.required_ruby_version = ">= 3.1"
 	
+  spec.add_dependency "async"	
 	spec.add_dependency "io-endpoint"
 end


### PR DESCRIPTION
[`async/dns`](https://github.com/socketry/async-dns/blob/bf8ef7de5171cf0493c2e584cad44aeb2ef3917a/lib/async/dns.rb#L7) requires the `async` file, so added `async` as a gem dependency.

## Types of Changes

- Bug fix.

## Contribution

<!-- Delete any which don't apply (you don't need to check all of them initially): -->

- [ ] I added tests for my changes.
- [x] I tested my changes locally.
- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
